### PR TITLE
fix: release comment detection

### DIFF
--- a/src/releaseTracking/updateIssueCommentsByRelease.ts
+++ b/src/releaseTracking/updateIssueCommentsByRelease.ts
@@ -12,7 +12,7 @@ export const updateIssueCommentByRelease = async (
   releasesAvailable: boolean,
 ): Promise<void> => {
   const comment = await getLastIssueComment(github, issue.number);
-  const isReleased = comment.includes('- release: [v');
+  const isReleased = comment.includes('- release: [');
 
   log(
     'I',

--- a/src/tests/releaseTracking/updateIssueCommentsByRelease.test.ts
+++ b/src/tests/releaseTracking/updateIssueCommentsByRelease.test.ts
@@ -78,6 +78,21 @@ it('Should not add a new comment if a release comment already exists', async () 
   expect(createIssueCommentMock).not.toHaveBeenCalled();
 });
 
+it('Should handle release comment without version prefix', async () => {
+  getLastIssueCommentMock.mockResolvedValue(
+    '- release: [0.9.0](https://github.com/...)',
+  );
+
+  await updateIssueCommentByRelease(
+    mockGitHub,
+    MOCK_ISSUE,
+    MOCK_RELEASE_INFO,
+    true,
+  );
+
+  expect(createIssueCommentMock).not.toHaveBeenCalled();
+});
+
 it('Should create a correct comment', async () => {
   getLastIssueCommentMock.mockResolvedValue('');
 


### PR DESCRIPTION
## Summary
- remove explanatory comments
- keep detection logic that allows tag names without `v`

## Testing
- `yarn lint` *(fails: request to registry.yarnpkg.com blocked)*
- `yarn test` *(fails: request to registry.yarnpkg.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685bb8e109088328bba039643e7f6927