### PR TITLE
Rename input helper module and update example plugin

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -43,6 +43,40 @@ graph TD
     style N fill:#fff3e0
 ```
 
+### Input Helpers
+
+Yuki-no exposes simple helpers for parsing raw inputs in your plugin:
+
+```ts
+import { getInput, getBooleanInput, getMultilineInput } from 'yuki-no';
+
+const token = getInput(ctx.inputs, 'my-token');
+const debug = getBooleanInput(ctx.inputs, 'debug');
+const paths = getMultilineInput(ctx.inputs, 'paths');
+```
+
+### Passing Inputs to Plugins
+
+Plugins can receive custom values using the action's `with` block just like any other GitHub Action input. These raw values are exposed on `ctx.inputs` for each plugin. Use the helpers above to parse them as needed.
+
+Example workflow configuration:
+
+```yaml
+- uses: Gumball12/yuki-no@v1
+  with:
+    plugins: |
+      ./plugins/example/index.js
+    my-plugin-input: ${{ secrets.EXAMPLE_TOKEN }}
+```
+
+Inside your plugin you can access the value:
+
+```ts
+import { getInput } from 'yuki-no';
+
+const token = getInput(ctx.inputs, 'my-plugin-input');
+```
+
 ### Hook Reference
 
 #### `onInit(ctx: YukiNoContext)`
@@ -79,7 +113,7 @@ Called when any error occurs during execution.
 type YukiNoContext = {
   octokit: Octokit; // GitHub API client (@octokit/rest)
   context: Context; // GitHub Actions context (@actions/github/lib/context)
-  inputs: Record<string, string>; // Action input parameters
+  inputs: Record<string, string>; // Raw `with` values from the workflow
 };
 
 type IssueMeta = {

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,7 @@ runs:
 
     - name: Run Yuki-no
       env:
+        RAW_INPUTS: ${{ toJson(inputs) }}
         ACCESS_TOKEN: ${{ inputs.access-token }}
         USER_NAME: ${{ inputs.username }}
         EMAIL: ${{ inputs.email }}

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/Gumball12/yuki-no#readme",
   "type": "module",
-  "main": "dist/types.d.ts",
-  "types": "dist/types.d.ts",
+  "main": "dist/public.d.ts",
+  "types": "dist/public.d.ts",
   "files": [
     "dist"
   ],

--- a/src/createConfig.ts
+++ b/src/createConfig.ts
@@ -1,4 +1,5 @@
-import { assert, excludeFrom, log, splitByNewline } from './utils';
+import { assert, excludeFrom, log } from './utils';
+import { getBooleanInput, getMultilineInput } from './inputUtils';
 
 import path from 'node:path';
 
@@ -68,21 +69,27 @@ export const createConfig = (): Config => {
   );
   const trackFrom = rawConfig.trackFrom;
 
-  const include = splitByNewline(rawConfig.include);
-  const exclude = splitByNewline(rawConfig.exclude);
-  const labels = splitByNewline(rawConfig.labels ?? defaults.label).sort();
+  const include = getMultilineInput(rawConfig, 'include');
+  const exclude = getMultilineInput(rawConfig, 'exclude');
 
-  const plugins = splitByNewline(rawConfig.plugins);
+  const labels = getMultilineInput(rawConfig, 'labels');
+  const sortedLabels = (labels.length ? labels : [defaults.label]).sort();
 
-  const releaseTracking = rawConfig.releaseTracking?.toLowerCase() === 'true';
+  const plugins = getMultilineInput(rawConfig, 'plugins');
+
+  const releaseTracking = getBooleanInput(rawConfig, 'releaseTracking');
+  const rawReleaseLabels = getMultilineInput(
+    rawConfig,
+    'releaseTrackingLabels',
+  );
   const releaseTrackingLabels = excludeFrom(
-    splitByNewline(
-      rawConfig.releaseTrackingLabels ?? defaults.releaseTrackingLabel,
-    ),
-    labels,
+    rawReleaseLabels.length
+      ? rawReleaseLabels
+      : [defaults.releaseTrackingLabel],
+    sortedLabels,
   );
 
-  const verbose = rawConfig.verbose?.toLowerCase() === 'true';
+  const verbose = getBooleanInput(rawConfig, 'verbose');
 
   return {
     accessToken,
@@ -93,7 +100,7 @@ export const createConfig = (): Config => {
     trackFrom,
     include,
     exclude,
-    labels,
+    labels: sortedLabels,
     releaseTracking,
     releaseTrackingLabels,
     plugins,

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,10 +41,11 @@ const start = async () => {
   log('S', 'GitHub initialized');
 
   const plugins = await loadPlugins(config.plugins);
+  const rawInputsEnv = process.env.RAW_INPUTS || '{}';
   const pluginCtx: YukiNoContext = {
     octokit: github.api,
     context: actionsContext,
-    inputs: process.env as Record<string, string>,
+    inputs: JSON.parse(rawInputsEnv) as Record<string, string>,
   };
 
   let success = false;

--- a/src/inputUtils.ts
+++ b/src/inputUtils.ts
@@ -1,0 +1,24 @@
+import { splitByNewline } from './utils';
+
+export const getInput = (
+  inputs: Record<string, string | undefined>,
+  name: string,
+): string | undefined => {
+  return inputs[name];
+};
+
+export const getBooleanInput = (
+  inputs: Record<string, string | undefined>,
+  name: string,
+): boolean => {
+  const value = getInput(inputs, name);
+  return value?.toLowerCase() === 'true';
+};
+
+export const getMultilineInput = (
+  inputs: Record<string, string | undefined>,
+  name: string,
+): string[] => {
+  const value = getInput(inputs, name);
+  return splitByNewline(value);
+};

--- a/src/plugins/example/index.ts
+++ b/src/plugins/example/index.ts
@@ -1,8 +1,26 @@
 import type { YukiNoPlugin } from '../core';
+import { getInput } from '../../inputUtils';
 
 const plugin: YukiNoPlugin = {
   name: 'yuki-no-example',
-  onInit() {},
+  onInit(ctx) {
+    // Plugins can read raw inputs defined in the workflow's `with` block via
+    // `ctx.inputs`. This example expects a value named `my-plugin-input`:
+    //
+    // ```yaml
+    // - uses: Gumball12/yuki-no@v1
+    //   with:
+    //     plugins: |
+    //       ./plugins/example/index.js
+    //     my-plugin-input: some-token
+    // ```
+    //
+    // Use the provided helpers to parse these values when needed.
+    const token = getInput(ctx.inputs, 'my-plugin-input');
+    if (token) {
+      console.log(`my-plugin-input: ${token}`);
+    }
+  },
   onBeforeCompare() {},
   onAfterCompare() {},
   onBeforeCreateIssue() {},

--- a/src/public.ts
+++ b/src/public.ts
@@ -1,2 +1,7 @@
 // Export plugin interface for external use
 export type { YukiNoPlugin } from './plugins/core';
+export {
+  getInput,
+  getBooleanInput,
+  getMultilineInput,
+} from './inputUtils';

--- a/src/tests/inputUtils.test.ts
+++ b/src/tests/inputUtils.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getInput,
+  getBooleanInput,
+  getMultilineInput,
+} from '../inputUtils';
+
+const INPUTS = {
+  token: 'abc123',
+  enabled: 'true',
+  paths: 'a\nb\nc',
+};
+
+describe('plugin input helpers', () => {
+  it('getInput returns raw string', () => {
+    expect(getInput(INPUTS, 'token')).toBe('abc123');
+  });
+
+  it('getBooleanInput parses booleans', () => {
+    expect(getBooleanInput(INPUTS, 'enabled')).toBe(true);
+    expect(getBooleanInput({ enabled: 'false' }, 'enabled')).toBe(false);
+  });
+
+  it('getMultilineInput splits lines', () => {
+    expect(getMultilineInput(INPUTS, 'paths')).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,6 +14,6 @@
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true
   },
-  "include": ["src/types.ts"],
+  "include": ["src/public.ts"],
   "exclude": ["src/tests/**/*", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- rename `src/input.ts` to `src/inputUtils.ts`
- update imports for renamed helper module
- move input helper tests to `src/tests/inputUtils.test.ts`
- demonstrate using `my-plugin-input` in the example plugin
- explain how plugin inputs work and update example comment
- tidy plugin docs

## Testing
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685d1ae096088328bba77eaccea2810b