### PR TITLE
fix: move release-tracking plugin installation to checkout phase

### DIFF
--- a/packages/core/createConfig.ts
+++ b/packages/core/createConfig.ts
@@ -1,5 +1,4 @@
 import type { Config, RepoSpec } from './types/config';
-import { unique } from './utils/common';
 import { getBooleanInput, getInput, getMultilineInput } from './utils/input';
 import { log } from './utils/log';
 
@@ -11,7 +10,6 @@ export const defaults = {
   branch: 'main',
   label: 'sync',
 } as const;
-
 
 export const createConfig = (): Config => {
   log('I', 'createConfig :: Parsing configuration values');

--- a/packages/core/createConfig.ts
+++ b/packages/core/createConfig.ts
@@ -12,8 +12,6 @@ export const defaults = {
   label: 'sync',
 } as const;
 
-export const RELEASE_TRACKING_COMPATIBILITY_PLUGIN_NAME =
-  '@yuki-no/plugin-release-tracking@latest';
 
 export const createConfig = (): Config => {
   log('I', 'createConfig :: Parsing configuration values');
@@ -49,12 +47,6 @@ export const createConfig = (): Config => {
   const verbose = getBooleanInput('VERBOSE', true);
   process.env.VERBOSE = verbose.toString();
 
-  // Compatibility layer: automatically add core plugin when release-tracking is enabled
-  const finalPlugins = [...plugins];
-  if (releaseTracking) {
-    finalPlugins.push(RELEASE_TRACKING_COMPATIBILITY_PLUGIN_NAME);
-  }
-
   return {
     accessToken: accessToken!,
     userName: userName!,
@@ -66,7 +58,7 @@ export const createConfig = (): Config => {
     exclude,
     labels: sortedLabels,
     releaseTracking,
-    plugins: unique(finalPlugins),
+    plugins,
     verbose,
   };
 };

--- a/packages/core/tests/createConfig.test.ts
+++ b/packages/core/tests/createConfig.test.ts
@@ -133,4 +133,3 @@ describe('Error handling', () => {
     );
   });
 });
-

--- a/packages/core/tests/createConfig.test.ts
+++ b/packages/core/tests/createConfig.test.ts
@@ -1,7 +1,6 @@
 import {
   createConfig,
   inferUpstreamRepo,
-  RELEASE_TRACKING_COMPATIBILITY_PLUGIN_NAME,
   defaults as yukiNoDefaults,
 } from '../createConfig';
 
@@ -103,10 +102,7 @@ describe('Custom envs processing', () => {
       exclude: ['node_modules', 'dist'],
       labels: ['label1', 'label2'].sort(),
       releaseTracking: true,
-      plugins: [
-        'yuki-no-plugin-example@1.0.0',
-        RELEASE_TRACKING_COMPATIBILITY_PLUGIN_NAME,
-      ],
+      plugins: ['yuki-no-plugin-example@1.0.0'],
       verbose: true,
     });
   });
@@ -138,95 +134,3 @@ describe('Error handling', () => {
   });
 });
 
-describe('Release tracking migration path', () => {
-  it('automatically adds release-tracking plugin when RELEASE_TRACKING=true', () => {
-    process.env.RELEASE_TRACKING = 'true';
-    process.env.PLUGINS = 'yuki-no-plugin-example@1.0.0';
-
-    const config = createConfig();
-
-    expect(config.releaseTracking).toBe(true);
-    expect(config.plugins).toEqual([
-      'yuki-no-plugin-example@1.0.0',
-      RELEASE_TRACKING_COMPATIBILITY_PLUGIN_NAME,
-    ]);
-  });
-
-  it('does not duplicate release-tracking plugin when both are specified', () => {
-    process.env.RELEASE_TRACKING = 'true';
-    process.env.PLUGINS = 'yuki-no-plugin-example@1.0.0\nrelease-tracking';
-
-    const config = createConfig();
-
-    expect(config.releaseTracking).toBe(true);
-    expect(config.plugins).toEqual([
-      'yuki-no-plugin-example@1.0.0',
-      'release-tracking',
-      RELEASE_TRACKING_COMPATIBILITY_PLUGIN_NAME,
-    ]);
-  });
-
-  it('does not add release-tracking plugin when RELEASE_TRACKING=false', () => {
-    process.env.RELEASE_TRACKING = 'false';
-    process.env.PLUGINS = 'yuki-no-plugin-example@1.0.0';
-
-    const config = createConfig();
-
-    expect(config.releaseTracking).toBe(false);
-    expect(config.plugins).toEqual(['yuki-no-plugin-example@1.0.0']);
-  });
-
-  it('handles release-tracking plugin with version specification', () => {
-    process.env.RELEASE_TRACKING = 'true';
-    process.env.PLUGINS =
-      'release-tracking@1.0.0\nyuki-no-plugin-example@1.0.0';
-
-    const config = createConfig();
-
-    expect(config.releaseTracking).toBe(true);
-    expect(config.plugins).toEqual([
-      'release-tracking@1.0.0',
-      'yuki-no-plugin-example@1.0.0',
-      RELEASE_TRACKING_COMPATIBILITY_PLUGIN_NAME,
-    ]);
-  });
-
-  it('handles scoped release-tracking plugin', () => {
-    process.env.RELEASE_TRACKING = 'true';
-    process.env.PLUGINS = RELEASE_TRACKING_COMPATIBILITY_PLUGIN_NAME;
-
-    const config = createConfig();
-
-    expect(config.releaseTracking).toBe(true);
-    expect(config.plugins).toEqual([
-      RELEASE_TRACKING_COMPATIBILITY_PLUGIN_NAME,
-    ]);
-  });
-
-  it('preserves plugin order when adding release-tracking', () => {
-    process.env.RELEASE_TRACKING = 'true';
-    process.env.PLUGINS = 'plugin-a@1.0.0\nplugin-b@2.0.0\nplugin-c@3.0.0';
-
-    const config = createConfig();
-
-    expect(config.releaseTracking).toBe(true);
-    expect(config.plugins).toEqual([
-      'plugin-a@1.0.0',
-      'plugin-b@2.0.0',
-      'plugin-c@3.0.0',
-      RELEASE_TRACKING_COMPATIBILITY_PLUGIN_NAME,
-    ]);
-  });
-
-  it('handles empty plugins list with release tracking enabled', () => {
-    process.env.RELEASE_TRACKING = 'true';
-    delete process.env.PLUGINS;
-
-    const config = createConfig();
-
-    expect(config.releaseTracking).toBe(true);
-    expect(config.plugins).toEqual([
-      RELEASE_TRACKING_COMPATIBILITY_PLUGIN_NAME,
-    ]);
-  });
-});

--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -29,6 +29,17 @@ fi
 echo "📦 Installing base dependencies..."
 pnpm install
 
+# Handle deprecated RELEASE_TRACKING option
+if [ "${RELEASE_TRACKING:-false}" = "true" ]; then
+  echo "⚠️  Warning: RELEASE_TRACKING is deprecated. Consider using plugins: ['@yuki-no/plugin-release-tracking@latest'] instead."
+  if [ -z "${PLUGINS:-}" ]; then
+    PLUGINS="@yuki-no/plugin-release-tracking@latest"
+  else
+    PLUGINS="${PLUGINS}
+@yuki-no/plugin-release-tracking@latest"
+  fi
+fi
+
 # Install plugins with exact version requirement
 if [ ! -z "${PLUGINS:-}" ]; then
   echo "🔌 Installing plugins with exact version requirement..."


### PR DESCRIPTION
## Summary
- Fixed release-tracking plugin installation issue by moving logic to checkout.sh
- Removed meaningless compatibility layer from createConfig.ts that wasn't actually installing plugins
- Cleaned up related tests that are no longer relevant

## Changes
- `scripts/checkout.sh`: Added RELEASE_TRACKING environment variable check to install `@yuki-no/plugin-release-tracking@latest` when needed
- `packages/core/createConfig.ts`: Removed ineffective plugin compatibility layer
- `packages/core/tests/createConfig.test.ts`: Removed tests for removed functionality

## Test plan
- [x] Verify checkout.sh properly handles RELEASE_TRACKING environment variable
- [x] Confirm plugin installation works in the checkout phase
- [x] Ensure existing tests still pass after cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)