### PR TITLE
fix: improve empty plugin string handling

### DIFF
--- a/packages/core/tests/createConfig.test.ts
+++ b/packages/core/tests/createConfig.test.ts
@@ -133,3 +133,29 @@ describe('Error handling', () => {
     );
   });
 });
+
+describe('Plugin handling edge cases', () => {
+  it('Filters out empty and whitespace-only plugin strings', () => {
+    process.env.PLUGINS = 'valid-plugin@1.0.0\n\n  \nvalid-plugin2@2.0.0\n   ';
+
+    const config = createConfig();
+
+    expect(config.plugins).toEqual(['valid-plugin@1.0.0', 'valid-plugin2@2.0.0']);
+  });
+
+  it('Returns empty array when all plugin strings are empty or whitespace', () => {
+    process.env.PLUGINS = '\n  \n   \n';
+
+    const config = createConfig();
+
+    expect(config.plugins).toEqual([]);
+  });
+
+  it('Handles single whitespace-only plugin string', () => {
+    process.env.PLUGINS = '   ';
+
+    const config = createConfig();
+
+    expect(config.plugins).toEqual([]);
+  });
+});

--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -45,8 +45,8 @@ if [ ! -z "${PLUGINS:-}" ]; then
   echo "🔌 Installing plugins with exact version requirement..."
   
   while IFS= read -r plugin; do
-    # Skip empty lines
-    [[ -z "$plugin" ]] && continue
+    # Skip empty lines and whitespace-only lines
+    [[ -z "${plugin// }" ]] && continue
     
     # Check for range versions (not allowed)
     if [[ "$plugin" =~ [~^] ]]; then


### PR DESCRIPTION
## Summary
• Updated shell script to properly filter out whitespace-only plugin strings
• Added comprehensive test coverage for empty and whitespace-only plugin edge cases
• Ensured consistent behavior between TypeScript and shell script implementations

## Test plan
- [x] Run existing test suite to ensure no regressions
- [x] Add new test cases covering empty string scenarios
- [x] Verify shell script correctly skips whitespace-only plugin entries
- [x] All tests pass (139 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)